### PR TITLE
Linting Fixes

### DIFF
--- a/message_test.go
+++ b/message_test.go
@@ -9,7 +9,6 @@ import (
 func TestParse(t *testing.T) {
 	is := is.New(t)
 
-	m := &Message{}
 	m, err := Parse("foo 1234 1425059762 my_public_key")
 	is.Err(err)
 	is.Equal(err, ErrInvalidNumMessageComponents)

--- a/server/line_protocol_server_test.go
+++ b/server/line_protocol_server_test.go
@@ -22,6 +22,7 @@ func TestLineProtocolServer(t *testing.T) {
 	}
 
 	s, err := NewLineProtocolServer(log.With(logger, "component", "line_protocol_server"), ":8095", fn)
+	is.NoErr(err)
 	is.NoErr(s.Run())
 	defer s.Stop()
 

--- a/server/metric_writer_carbon_test.go
+++ b/server/metric_writer_carbon_test.go
@@ -20,6 +20,7 @@ func TestMetricWriterCarbon(t *testing.T) {
 	}
 
 	s, err := NewLineProtocolServer(log.With(logger, "component", "line_protocol_server"), ":8096", fn)
+	is.NoErr(err)
 	is.NoErr(s.Run())
 	defer s.Stop()
 


### PR DESCRIPTION
amproxy: dispense with redundant variable
server: fix dropped test errors

If you had to do it all over again, would you still use `github.com/cheekybits/is`?